### PR TITLE
hotfix: change version code to actual in PlayMarket

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId "com.github.braillesystems.learnbraille"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 7
+        versionCode 8
         versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
APK version code needed to be changed when Beta was made public, so 8 is the true version code of release 1.0.2