### PR TITLE
#308 fix TalkBack pronunciation on entering an Info fragment

### DIFF
--- a/app/src/main/java/com/github/braillesystems/learnbraille/ui/screens/theory/steps/info/AbstractInfoStepFragment.kt
+++ b/app/src/main/java/com/github/braillesystems/learnbraille/ui/screens/theory/steps/info/AbstractInfoStepFragment.kt
@@ -5,6 +5,7 @@ import com.github.braillesystems.learnbraille.data.entities.BaseInfo
 import com.github.braillesystems.learnbraille.ui.screens.HelpMsgId
 import com.github.braillesystems.learnbraille.ui.screens.theory.steps.AbstractStepFragment
 import com.github.braillesystems.learnbraille.utils.checkedAnnounce
+import com.github.braillesystems.learnbraille.utils.reduceWhitespaces
 
 abstract class AbstractInfoStepFragment(helpMsgId: HelpMsgId) : AbstractStepFragment(helpMsgId) {
 
@@ -12,6 +13,6 @@ abstract class AbstractInfoStepFragment(helpMsgId: HelpMsgId) : AbstractStepFrag
         val data = step.data
         require(data is BaseInfo)
         stepBinding.textView?.text = data.text.parseAsHtml()
-        checkedAnnounce(data.text)
+        checkedAnnounce(data.text.reduceWhitespaces())
     }
 }

--- a/app/src/main/java/com/github/braillesystems/learnbraille/utils/_Kotlin.kt
+++ b/app/src/main/java/com/github/braillesystems/learnbraille/utils/_Kotlin.kt
@@ -46,6 +46,8 @@ operator fun <A, B> Pair<A, B>.compareTo(other: Pair<A, B>): Int
 
 fun String.removeHtmlMarkup() = Regex("""<[^>]*>|&""").replace(this, "")
 
+fun String.reduceWhitespaces() = Regex("  +|\n").replace(this, " ")
+
 inline fun runIf(cond: Boolean, block: () -> Unit) {
     if (cond) block()
 }


### PR DESCRIPTION
Closes #308 

(whitespaces and newlines are now removed in a text that is passed to `checkedAnnounce` in `Info` steps)